### PR TITLE
kafka.Topic: Allow seemless upgrade from httpEndpoint to restEndpoint

### DIFF
--- a/provider/cmd/pulumi-resource-confluentcloud/schema.json
+++ b/provider/cmd/pulumi-resource-confluentcloud/schema.json
@@ -1897,6 +1897,11 @@
                     "$ref": "#/types/confluentcloud:index/KafkaTopicCredentials:KafkaTopicCredentials",
                     "description": "The Cluster API Credentials.\n"
                 },
+                "httpEndpoint": {
+                    "type": "string",
+                    "description": "The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).\n",
+                    "deprecationMessage": "This parameter has been deprecated in favour of Rest Endpoint"
+                },
                 "kafkaCluster": {
                     "$ref": "#/types/confluentcloud:index/KafkaTopicKafkaCluster:KafkaTopicKafkaCluster"
                 },
@@ -1915,6 +1920,7 @@
             },
             "required": [
                 "config",
+                "httpEndpoint",
                 "kafkaCluster",
                 "topicName"
             ],
@@ -1929,6 +1935,11 @@
                 "credentials": {
                     "$ref": "#/types/confluentcloud:index/KafkaTopicCredentials:KafkaTopicCredentials",
                     "description": "The Cluster API Credentials.\n"
+                },
+                "httpEndpoint": {
+                    "type": "string",
+                    "description": "The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).\n",
+                    "deprecationMessage": "This parameter has been deprecated in favour of Rest Endpoint"
                 },
                 "kafkaCluster": {
                     "$ref": "#/types/confluentcloud:index/KafkaTopicKafkaCluster:KafkaTopicKafkaCluster",
@@ -1967,6 +1978,11 @@
                     "credentials": {
                         "$ref": "#/types/confluentcloud:index/KafkaTopicCredentials:KafkaTopicCredentials",
                         "description": "The Cluster API Credentials.\n"
+                    },
+                    "httpEndpoint": {
+                        "type": "string",
+                        "description": "The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).\n",
+                        "deprecationMessage": "This parameter has been deprecated in favour of Rest Endpoint"
                     },
                     "kafkaCluster": {
                         "$ref": "#/types/confluentcloud:index/KafkaTopicKafkaCluster:KafkaTopicKafkaCluster",

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -3,6 +3,7 @@ module github.com/pulumi/pulumi-confluentcloud/provider
 go 1.18
 
 replace (
+	github.com/confluentinc/terraform-provider-confluent => github.com/pulumi/terraform-provider-confluent v0.0.0-20220819222606-421fbb8d0482
 	github.com/confluentinc/terraform-provider-confluent/shim => ./shim
 	github.com/hashicorp/go-getter v1.5.0 => github.com/hashicorp/go-getter v1.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220725190814-23001ad6ec03

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -272,8 +272,6 @@ github.com/confluentinc/ccloud-sdk-go-v2/networking v0.2.0 h1:tXxfF1Nq90ca/xf3gc
 github.com/confluentinc/ccloud-sdk-go-v2/networking v0.2.0/go.mod h1:EcmHhRib8dDuO5ZsO+qS3scX9xEP5E/IXOVoItp5X2s=
 github.com/confluentinc/ccloud-sdk-go-v2/org v0.4.0 h1:WcJs6RbY8nU5HapaG0ZCH9ftFBtZyuKMIuNAkdVmc2o=
 github.com/confluentinc/ccloud-sdk-go-v2/org v0.4.0/go.mod h1:zREJ+OOZz0rEXCaPx0JbCVj2EfNnYs/c6qhPDfhldI0=
-github.com/confluentinc/terraform-provider-confluent v1.1.0 h1:5/p+U3XVemASZnUNM5RidBMhIxyJorStRdRPGf5ShHA=
-github.com/confluentinc/terraform-provider-confluent v1.1.0/go.mod h1:wYiM6dryZ52LqFIpE174d4MddpQchDl4wlsRXPpOlLw=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/cgroups v1.0.3 h1:ADZftAkglvCiD44c77s5YmMqaP2pzVCFZvBmAlBdAP4=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
@@ -842,6 +840,8 @@ github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e h1:Di
 github.com/pulumi/terraform-diff-reader v0.0.0-20201211191010-ad4715e9285e/go.mod h1:sZ9FUzGO+yM41hsQHs/yIcj/Y993qMdBxBU5mpDmAfQ=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220725190814-23001ad6ec03 h1:J06u+TRoOQ9C6JZlXNvmOE5Il4/WdXslx5bOUIRZtDI=
 github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20220725190814-23001ad6ec03/go.mod h1:/WYikYjhKB7c2j1HmXZhRsAARldRb4M38bLCLOhC3so=
+github.com/pulumi/terraform-provider-confluent v0.0.0-20220819222606-421fbb8d0482 h1:h8iGOIPurZs0ax38i6pVcqlZWLy9Mqxgg15N+yD0WcI=
+github.com/pulumi/terraform-provider-confluent v0.0.0-20220819222606-421fbb8d0482/go.mod h1:wYiM6dryZ52LqFIpE174d4MddpQchDl4wlsRXPpOlLw=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=

--- a/provider/shim/go.mod
+++ b/provider/shim/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
 )
 
+replace github.com/confluentinc/terraform-provider-confluent => github.com/pulumi/terraform-provider-confluent v0.0.0-20220819222606-421fbb8d0482
+
 require (
 	github.com/agext/levenshtein v1.2.2 // indirect
 	github.com/antihax/optional v1.0.0 // indirect

--- a/provider/shim/go.sum
+++ b/provider/shim/go.sum
@@ -87,8 +87,6 @@ github.com/confluentinc/ccloud-sdk-go-v2/networking v0.2.0 h1:tXxfF1Nq90ca/xf3gc
 github.com/confluentinc/ccloud-sdk-go-v2/networking v0.2.0/go.mod h1:EcmHhRib8dDuO5ZsO+qS3scX9xEP5E/IXOVoItp5X2s=
 github.com/confluentinc/ccloud-sdk-go-v2/org v0.4.0 h1:WcJs6RbY8nU5HapaG0ZCH9ftFBtZyuKMIuNAkdVmc2o=
 github.com/confluentinc/ccloud-sdk-go-v2/org v0.4.0/go.mod h1:zREJ+OOZz0rEXCaPx0JbCVj2EfNnYs/c6qhPDfhldI0=
-github.com/confluentinc/terraform-provider-confluent v1.1.0 h1:5/p+U3XVemASZnUNM5RidBMhIxyJorStRdRPGf5ShHA=
-github.com/confluentinc/terraform-provider-confluent v1.1.0/go.mod h1:wYiM6dryZ52LqFIpE174d4MddpQchDl4wlsRXPpOlLw=
 github.com/containerd/cgroups v1.0.3 h1:ADZftAkglvCiD44c77s5YmMqaP2pzVCFZvBmAlBdAP4=
 github.com/containerd/containerd v1.6.1 h1:oa2uY0/0G+JX4X7hpGCYvkp9FjUancz56kSNnb1sG3o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -302,6 +300,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/pulumi/terraform-provider-confluent v0.0.0-20220819222606-421fbb8d0482 h1:h8iGOIPurZs0ax38i6pVcqlZWLy9Mqxgg15N+yD0WcI=
+github.com/pulumi/terraform-provider-confluent v0.0.0-20220819222606-421fbb8d0482/go.mod h1:wYiM6dryZ52LqFIpE174d4MddpQchDl4wlsRXPpOlLw=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/samber/lo v1.20.0 h1:20FtphdORvp4yxklurzZv2HX+g+0urEMQziODC5bV70=

--- a/sdk/dotnet/KafkaTopic.cs
+++ b/sdk/dotnet/KafkaTopic.cs
@@ -115,6 +115,12 @@ namespace Pulumi.ConfluentCloud
         [Output("credentials")]
         public Output<Outputs.KafkaTopicCredentials?> Credentials { get; private set; } = null!;
 
+        /// <summary>
+        /// The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+        /// </summary>
+        [Output("httpEndpoint")]
+        public Output<string> HttpEndpoint { get; private set; } = null!;
+
         [Output("kafkaCluster")]
         public Output<Outputs.KafkaTopicKafkaCluster> KafkaCluster { get; private set; } = null!;
 
@@ -200,6 +206,12 @@ namespace Pulumi.ConfluentCloud
         [Input("credentials")]
         public Input<Inputs.KafkaTopicCredentialsArgs>? Credentials { get; set; }
 
+        /// <summary>
+        /// The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+        /// </summary>
+        [Input("httpEndpoint")]
+        public Input<string>? HttpEndpoint { get; set; }
+
         [Input("kafkaCluster", required: true)]
         public Input<Inputs.KafkaTopicKafkaClusterArgs> KafkaCluster { get; set; } = null!;
 
@@ -246,6 +258,12 @@ namespace Pulumi.ConfluentCloud
         /// </summary>
         [Input("credentials")]
         public Input<Inputs.KafkaTopicCredentialsGetArgs>? Credentials { get; set; }
+
+        /// <summary>
+        /// The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+        /// </summary>
+        [Input("httpEndpoint")]
+        public Input<string>? HttpEndpoint { get; set; }
 
         [Input("kafkaCluster")]
         public Input<Inputs.KafkaTopicKafkaClusterGetArgs>? KafkaCluster { get; set; }

--- a/sdk/go/confluentcloud/kafkaTopic.go
+++ b/sdk/go/confluentcloud/kafkaTopic.go
@@ -108,8 +108,12 @@ type KafkaTopic struct {
 	// The custom topic settings to set:
 	Config pulumi.StringMapOutput `pulumi:"config"`
 	// The Cluster API Credentials.
-	Credentials  KafkaTopicCredentialsPtrOutput `pulumi:"credentials"`
-	KafkaCluster KafkaTopicKafkaClusterOutput   `pulumi:"kafkaCluster"`
+	Credentials KafkaTopicCredentialsPtrOutput `pulumi:"credentials"`
+	// The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+	//
+	// Deprecated: This parameter has been deprecated in favour of Rest Endpoint
+	HttpEndpoint pulumi.StringOutput          `pulumi:"httpEndpoint"`
+	KafkaCluster KafkaTopicKafkaClusterOutput `pulumi:"kafkaCluster"`
 	// The number of partitions to create in the topic. Defaults to `6`.
 	PartitionsCount pulumi.IntPtrOutput `pulumi:"partitionsCount"`
 	// The REST endpoint of the Kafka cluster, for example, `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
@@ -156,7 +160,11 @@ type kafkaTopicState struct {
 	// The custom topic settings to set:
 	Config map[string]string `pulumi:"config"`
 	// The Cluster API Credentials.
-	Credentials  *KafkaTopicCredentials  `pulumi:"credentials"`
+	Credentials *KafkaTopicCredentials `pulumi:"credentials"`
+	// The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+	//
+	// Deprecated: This parameter has been deprecated in favour of Rest Endpoint
+	HttpEndpoint *string                 `pulumi:"httpEndpoint"`
 	KafkaCluster *KafkaTopicKafkaCluster `pulumi:"kafkaCluster"`
 	// The number of partitions to create in the topic. Defaults to `6`.
 	PartitionsCount *int `pulumi:"partitionsCount"`
@@ -170,7 +178,11 @@ type KafkaTopicState struct {
 	// The custom topic settings to set:
 	Config pulumi.StringMapInput
 	// The Cluster API Credentials.
-	Credentials  KafkaTopicCredentialsPtrInput
+	Credentials KafkaTopicCredentialsPtrInput
+	// The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+	//
+	// Deprecated: This parameter has been deprecated in favour of Rest Endpoint
+	HttpEndpoint pulumi.StringPtrInput
 	KafkaCluster KafkaTopicKafkaClusterPtrInput
 	// The number of partitions to create in the topic. Defaults to `6`.
 	PartitionsCount pulumi.IntPtrInput
@@ -188,7 +200,11 @@ type kafkaTopicArgs struct {
 	// The custom topic settings to set:
 	Config map[string]string `pulumi:"config"`
 	// The Cluster API Credentials.
-	Credentials  *KafkaTopicCredentials `pulumi:"credentials"`
+	Credentials *KafkaTopicCredentials `pulumi:"credentials"`
+	// The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+	//
+	// Deprecated: This parameter has been deprecated in favour of Rest Endpoint
+	HttpEndpoint *string                `pulumi:"httpEndpoint"`
 	KafkaCluster KafkaTopicKafkaCluster `pulumi:"kafkaCluster"`
 	// The number of partitions to create in the topic. Defaults to `6`.
 	PartitionsCount *int `pulumi:"partitionsCount"`
@@ -203,7 +219,11 @@ type KafkaTopicArgs struct {
 	// The custom topic settings to set:
 	Config pulumi.StringMapInput
 	// The Cluster API Credentials.
-	Credentials  KafkaTopicCredentialsPtrInput
+	Credentials KafkaTopicCredentialsPtrInput
+	// The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+	//
+	// Deprecated: This parameter has been deprecated in favour of Rest Endpoint
+	HttpEndpoint pulumi.StringPtrInput
 	KafkaCluster KafkaTopicKafkaClusterInput
 	// The number of partitions to create in the topic. Defaults to `6`.
 	PartitionsCount pulumi.IntPtrInput
@@ -308,6 +328,13 @@ func (o KafkaTopicOutput) Config() pulumi.StringMapOutput {
 // The Cluster API Credentials.
 func (o KafkaTopicOutput) Credentials() KafkaTopicCredentialsPtrOutput {
 	return o.ApplyT(func(v *KafkaTopic) KafkaTopicCredentialsPtrOutput { return v.Credentials }).(KafkaTopicCredentialsPtrOutput)
+}
+
+// The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+//
+// Deprecated: This parameter has been deprecated in favour of Rest Endpoint
+func (o KafkaTopicOutput) HttpEndpoint() pulumi.StringOutput {
+	return o.ApplyT(func(v *KafkaTopic) pulumi.StringOutput { return v.HttpEndpoint }).(pulumi.StringOutput)
 }
 
 func (o KafkaTopicOutput) KafkaCluster() KafkaTopicKafkaClusterOutput {

--- a/sdk/java/src/main/java/com/pulumi/confluentcloud/KafkaTopic.java
+++ b/sdk/java/src/main/java/com/pulumi/confluentcloud/KafkaTopic.java
@@ -140,6 +140,24 @@ public class KafkaTopic extends com.pulumi.resources.CustomResource {
     public Output<Optional<KafkaTopicCredentials>> credentials() {
         return Codegen.optional(this.credentials);
     }
+    /**
+     * The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+     * 
+     * @deprecated
+     * This parameter has been deprecated in favour of Rest Endpoint
+     * 
+     */
+    @Deprecated /* This parameter has been deprecated in favour of Rest Endpoint */
+    @Export(name="httpEndpoint", type=String.class, parameters={})
+    private Output<String> httpEndpoint;
+
+    /**
+     * @return The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+     * 
+     */
+    public Output<String> httpEndpoint() {
+        return this.httpEndpoint;
+    }
     @Export(name="kafkaCluster", type=KafkaTopicKafkaCluster.class, parameters={})
     private Output<KafkaTopicKafkaCluster> kafkaCluster;
 

--- a/sdk/java/src/main/java/com/pulumi/confluentcloud/KafkaTopicArgs.java
+++ b/sdk/java/src/main/java/com/pulumi/confluentcloud/KafkaTopicArgs.java
@@ -49,6 +49,29 @@ public final class KafkaTopicArgs extends com.pulumi.resources.ResourceArgs {
         return Optional.ofNullable(this.credentials);
     }
 
+    /**
+     * The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+     * 
+     * @deprecated
+     * This parameter has been deprecated in favour of Rest Endpoint
+     * 
+     */
+    @Deprecated /* This parameter has been deprecated in favour of Rest Endpoint */
+    @Import(name="httpEndpoint")
+    private @Nullable Output<String> httpEndpoint;
+
+    /**
+     * @return The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+     * 
+     * @deprecated
+     * This parameter has been deprecated in favour of Rest Endpoint
+     * 
+     */
+    @Deprecated /* This parameter has been deprecated in favour of Rest Endpoint */
+    public Optional<Output<String>> httpEndpoint() {
+        return Optional.ofNullable(this.httpEndpoint);
+    }
+
     @Import(name="kafkaCluster", required=true)
     private Output<KafkaTopicKafkaClusterArgs> kafkaCluster;
 
@@ -106,6 +129,7 @@ public final class KafkaTopicArgs extends com.pulumi.resources.ResourceArgs {
     private KafkaTopicArgs(KafkaTopicArgs $) {
         this.config = $.config;
         this.credentials = $.credentials;
+        this.httpEndpoint = $.httpEndpoint;
         this.kafkaCluster = $.kafkaCluster;
         this.partitionsCount = $.partitionsCount;
         this.restEndpoint = $.restEndpoint;
@@ -170,6 +194,35 @@ public final class KafkaTopicArgs extends com.pulumi.resources.ResourceArgs {
          */
         public Builder credentials(KafkaTopicCredentialsArgs credentials) {
             return credentials(Output.of(credentials));
+        }
+
+        /**
+         * @param httpEndpoint The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+         * 
+         * @return builder
+         * 
+         * @deprecated
+         * This parameter has been deprecated in favour of Rest Endpoint
+         * 
+         */
+        @Deprecated /* This parameter has been deprecated in favour of Rest Endpoint */
+        public Builder httpEndpoint(@Nullable Output<String> httpEndpoint) {
+            $.httpEndpoint = httpEndpoint;
+            return this;
+        }
+
+        /**
+         * @param httpEndpoint The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+         * 
+         * @return builder
+         * 
+         * @deprecated
+         * This parameter has been deprecated in favour of Rest Endpoint
+         * 
+         */
+        @Deprecated /* This parameter has been deprecated in favour of Rest Endpoint */
+        public Builder httpEndpoint(String httpEndpoint) {
+            return httpEndpoint(Output.of(httpEndpoint));
         }
 
         public Builder kafkaCluster(Output<KafkaTopicKafkaClusterArgs> kafkaCluster) {

--- a/sdk/java/src/main/java/com/pulumi/confluentcloud/inputs/KafkaTopicState.java
+++ b/sdk/java/src/main/java/com/pulumi/confluentcloud/inputs/KafkaTopicState.java
@@ -49,6 +49,29 @@ public final class KafkaTopicState extends com.pulumi.resources.ResourceArgs {
         return Optional.ofNullable(this.credentials);
     }
 
+    /**
+     * The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+     * 
+     * @deprecated
+     * This parameter has been deprecated in favour of Rest Endpoint
+     * 
+     */
+    @Deprecated /* This parameter has been deprecated in favour of Rest Endpoint */
+    @Import(name="httpEndpoint")
+    private @Nullable Output<String> httpEndpoint;
+
+    /**
+     * @return The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+     * 
+     * @deprecated
+     * This parameter has been deprecated in favour of Rest Endpoint
+     * 
+     */
+    @Deprecated /* This parameter has been deprecated in favour of Rest Endpoint */
+    public Optional<Output<String>> httpEndpoint() {
+        return Optional.ofNullable(this.httpEndpoint);
+    }
+
     @Import(name="kafkaCluster")
     private @Nullable Output<KafkaTopicKafkaClusterArgs> kafkaCluster;
 
@@ -106,6 +129,7 @@ public final class KafkaTopicState extends com.pulumi.resources.ResourceArgs {
     private KafkaTopicState(KafkaTopicState $) {
         this.config = $.config;
         this.credentials = $.credentials;
+        this.httpEndpoint = $.httpEndpoint;
         this.kafkaCluster = $.kafkaCluster;
         this.partitionsCount = $.partitionsCount;
         this.restEndpoint = $.restEndpoint;
@@ -170,6 +194,35 @@ public final class KafkaTopicState extends com.pulumi.resources.ResourceArgs {
          */
         public Builder credentials(KafkaTopicCredentialsArgs credentials) {
             return credentials(Output.of(credentials));
+        }
+
+        /**
+         * @param httpEndpoint The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+         * 
+         * @return builder
+         * 
+         * @deprecated
+         * This parameter has been deprecated in favour of Rest Endpoint
+         * 
+         */
+        @Deprecated /* This parameter has been deprecated in favour of Rest Endpoint */
+        public Builder httpEndpoint(@Nullable Output<String> httpEndpoint) {
+            $.httpEndpoint = httpEndpoint;
+            return this;
+        }
+
+        /**
+         * @param httpEndpoint The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+         * 
+         * @return builder
+         * 
+         * @deprecated
+         * This parameter has been deprecated in favour of Rest Endpoint
+         * 
+         */
+        @Deprecated /* This parameter has been deprecated in favour of Rest Endpoint */
+        public Builder httpEndpoint(String httpEndpoint) {
+            return httpEndpoint(Output.of(httpEndpoint));
         }
 
         public Builder kafkaCluster(@Nullable Output<KafkaTopicKafkaClusterArgs> kafkaCluster) {

--- a/sdk/nodejs/kafkaTopic.ts
+++ b/sdk/nodejs/kafkaTopic.ts
@@ -132,6 +132,12 @@ export class KafkaTopic extends pulumi.CustomResource {
      * The Cluster API Credentials.
      */
     public readonly credentials!: pulumi.Output<outputs.KafkaTopicCredentials | undefined>;
+    /**
+     * The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+     *
+     * @deprecated This parameter has been deprecated in favour of Rest Endpoint
+     */
+    public readonly httpEndpoint!: pulumi.Output<string>;
     public readonly kafkaCluster!: pulumi.Output<outputs.KafkaTopicKafkaCluster>;
     /**
      * The number of partitions to create in the topic. Defaults to `6`.
@@ -161,6 +167,7 @@ export class KafkaTopic extends pulumi.CustomResource {
             const state = argsOrState as KafkaTopicState | undefined;
             resourceInputs["config"] = state ? state.config : undefined;
             resourceInputs["credentials"] = state ? state.credentials : undefined;
+            resourceInputs["httpEndpoint"] = state ? state.httpEndpoint : undefined;
             resourceInputs["kafkaCluster"] = state ? state.kafkaCluster : undefined;
             resourceInputs["partitionsCount"] = state ? state.partitionsCount : undefined;
             resourceInputs["restEndpoint"] = state ? state.restEndpoint : undefined;
@@ -175,6 +182,7 @@ export class KafkaTopic extends pulumi.CustomResource {
             }
             resourceInputs["config"] = args ? args.config : undefined;
             resourceInputs["credentials"] = args ? args.credentials : undefined;
+            resourceInputs["httpEndpoint"] = args ? args.httpEndpoint : undefined;
             resourceInputs["kafkaCluster"] = args ? args.kafkaCluster : undefined;
             resourceInputs["partitionsCount"] = args ? args.partitionsCount : undefined;
             resourceInputs["restEndpoint"] = args ? args.restEndpoint : undefined;
@@ -197,6 +205,12 @@ export interface KafkaTopicState {
      * The Cluster API Credentials.
      */
     credentials?: pulumi.Input<inputs.KafkaTopicCredentials>;
+    /**
+     * The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+     *
+     * @deprecated This parameter has been deprecated in favour of Rest Endpoint
+     */
+    httpEndpoint?: pulumi.Input<string>;
     kafkaCluster?: pulumi.Input<inputs.KafkaTopicKafkaCluster>;
     /**
      * The number of partitions to create in the topic. Defaults to `6`.
@@ -224,6 +238,12 @@ export interface KafkaTopicArgs {
      * The Cluster API Credentials.
      */
     credentials?: pulumi.Input<inputs.KafkaTopicCredentials>;
+    /**
+     * The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+     *
+     * @deprecated This parameter has been deprecated in favour of Rest Endpoint
+     */
+    httpEndpoint?: pulumi.Input<string>;
     kafkaCluster: pulumi.Input<inputs.KafkaTopicKafkaCluster>;
     /**
      * The number of partitions to create in the topic. Defaults to `6`.

--- a/sdk/python/pulumi_confluentcloud/kafka_topic.py
+++ b/sdk/python/pulumi_confluentcloud/kafka_topic.py
@@ -20,6 +20,7 @@ class KafkaTopicArgs:
                  topic_name: pulumi.Input[str],
                  config: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  credentials: Optional[pulumi.Input['KafkaTopicCredentialsArgs']] = None,
+                 http_endpoint: Optional[pulumi.Input[str]] = None,
                  partitions_count: Optional[pulumi.Input[int]] = None,
                  rest_endpoint: Optional[pulumi.Input[str]] = None):
         """
@@ -27,6 +28,7 @@ class KafkaTopicArgs:
         :param pulumi.Input[str] topic_name: The name of the topic, for example, `orders-1`. The topic name can be up to 249 characters in length, and can include the following characters: a-z, A-Z, 0-9, . (dot), _ (underscore), and - (dash). As a best practice, we recommend against using any personally identifiable information (PII) when naming your topic.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] config: The custom topic settings to set:
         :param pulumi.Input['KafkaTopicCredentialsArgs'] credentials: The Cluster API Credentials.
+        :param pulumi.Input[str] http_endpoint: The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
         :param pulumi.Input[int] partitions_count: The number of partitions to create in the topic. Defaults to `6`.
         :param pulumi.Input[str] rest_endpoint: The REST endpoint of the Kafka cluster, for example, `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
         """
@@ -36,6 +38,11 @@ class KafkaTopicArgs:
             pulumi.set(__self__, "config", config)
         if credentials is not None:
             pulumi.set(__self__, "credentials", credentials)
+        if http_endpoint is not None:
+            warnings.warn("""This parameter has been deprecated in favour of Rest Endpoint""", DeprecationWarning)
+            pulumi.log.warn("""http_endpoint is deprecated: This parameter has been deprecated in favour of Rest Endpoint""")
+        if http_endpoint is not None:
+            pulumi.set(__self__, "http_endpoint", http_endpoint)
         if partitions_count is not None:
             pulumi.set(__self__, "partitions_count", partitions_count)
         if rest_endpoint is not None:
@@ -87,6 +94,18 @@ class KafkaTopicArgs:
         pulumi.set(self, "credentials", value)
 
     @property
+    @pulumi.getter(name="httpEndpoint")
+    def http_endpoint(self) -> Optional[pulumi.Input[str]]:
+        """
+        The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+        """
+        return pulumi.get(self, "http_endpoint")
+
+    @http_endpoint.setter
+    def http_endpoint(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "http_endpoint", value)
+
+    @property
     @pulumi.getter(name="partitionsCount")
     def partitions_count(self) -> Optional[pulumi.Input[int]]:
         """
@@ -116,6 +135,7 @@ class _KafkaTopicState:
     def __init__(__self__, *,
                  config: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  credentials: Optional[pulumi.Input['KafkaTopicCredentialsArgs']] = None,
+                 http_endpoint: Optional[pulumi.Input[str]] = None,
                  kafka_cluster: Optional[pulumi.Input['KafkaTopicKafkaClusterArgs']] = None,
                  partitions_count: Optional[pulumi.Input[int]] = None,
                  rest_endpoint: Optional[pulumi.Input[str]] = None,
@@ -124,6 +144,7 @@ class _KafkaTopicState:
         Input properties used for looking up and filtering KafkaTopic resources.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] config: The custom topic settings to set:
         :param pulumi.Input['KafkaTopicCredentialsArgs'] credentials: The Cluster API Credentials.
+        :param pulumi.Input[str] http_endpoint: The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
         :param pulumi.Input[int] partitions_count: The number of partitions to create in the topic. Defaults to `6`.
         :param pulumi.Input[str] rest_endpoint: The REST endpoint of the Kafka cluster, for example, `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
         :param pulumi.Input[str] topic_name: The name of the topic, for example, `orders-1`. The topic name can be up to 249 characters in length, and can include the following characters: a-z, A-Z, 0-9, . (dot), _ (underscore), and - (dash). As a best practice, we recommend against using any personally identifiable information (PII) when naming your topic.
@@ -132,6 +153,11 @@ class _KafkaTopicState:
             pulumi.set(__self__, "config", config)
         if credentials is not None:
             pulumi.set(__self__, "credentials", credentials)
+        if http_endpoint is not None:
+            warnings.warn("""This parameter has been deprecated in favour of Rest Endpoint""", DeprecationWarning)
+            pulumi.log.warn("""http_endpoint is deprecated: This parameter has been deprecated in favour of Rest Endpoint""")
+        if http_endpoint is not None:
+            pulumi.set(__self__, "http_endpoint", http_endpoint)
         if kafka_cluster is not None:
             pulumi.set(__self__, "kafka_cluster", kafka_cluster)
         if partitions_count is not None:
@@ -164,6 +190,18 @@ class _KafkaTopicState:
     @credentials.setter
     def credentials(self, value: Optional[pulumi.Input['KafkaTopicCredentialsArgs']]):
         pulumi.set(self, "credentials", value)
+
+    @property
+    @pulumi.getter(name="httpEndpoint")
+    def http_endpoint(self) -> Optional[pulumi.Input[str]]:
+        """
+        The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+        """
+        return pulumi.get(self, "http_endpoint")
+
+    @http_endpoint.setter
+    def http_endpoint(self, value: Optional[pulumi.Input[str]]):
+        pulumi.set(self, "http_endpoint", value)
 
     @property
     @pulumi.getter(name="kafkaCluster")
@@ -218,6 +256,7 @@ class KafkaTopic(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  config: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  credentials: Optional[pulumi.Input[pulumi.InputType['KafkaTopicCredentialsArgs']]] = None,
+                 http_endpoint: Optional[pulumi.Input[str]] = None,
                  kafka_cluster: Optional[pulumi.Input[pulumi.InputType['KafkaTopicKafkaClusterArgs']]] = None,
                  partitions_count: Optional[pulumi.Input[int]] = None,
                  rest_endpoint: Optional[pulumi.Input[str]] = None,
@@ -318,6 +357,7 @@ class KafkaTopic(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] config: The custom topic settings to set:
         :param pulumi.Input[pulumi.InputType['KafkaTopicCredentialsArgs']] credentials: The Cluster API Credentials.
+        :param pulumi.Input[str] http_endpoint: The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
         :param pulumi.Input[int] partitions_count: The number of partitions to create in the topic. Defaults to `6`.
         :param pulumi.Input[str] rest_endpoint: The REST endpoint of the Kafka cluster, for example, `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
         :param pulumi.Input[str] topic_name: The name of the topic, for example, `orders-1`. The topic name can be up to 249 characters in length, and can include the following characters: a-z, A-Z, 0-9, . (dot), _ (underscore), and - (dash). As a best practice, we recommend against using any personally identifiable information (PII) when naming your topic.
@@ -436,6 +476,7 @@ class KafkaTopic(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  config: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
                  credentials: Optional[pulumi.Input[pulumi.InputType['KafkaTopicCredentialsArgs']]] = None,
+                 http_endpoint: Optional[pulumi.Input[str]] = None,
                  kafka_cluster: Optional[pulumi.Input[pulumi.InputType['KafkaTopicKafkaClusterArgs']]] = None,
                  partitions_count: Optional[pulumi.Input[int]] = None,
                  rest_endpoint: Optional[pulumi.Input[str]] = None,
@@ -451,6 +492,10 @@ class KafkaTopic(pulumi.CustomResource):
 
             __props__.__dict__["config"] = config
             __props__.__dict__["credentials"] = credentials
+            if http_endpoint is not None and not opts.urn:
+                warnings.warn("""This parameter has been deprecated in favour of Rest Endpoint""", DeprecationWarning)
+                pulumi.log.warn("""http_endpoint is deprecated: This parameter has been deprecated in favour of Rest Endpoint""")
+            __props__.__dict__["http_endpoint"] = http_endpoint
             if kafka_cluster is None and not opts.urn:
                 raise TypeError("Missing required property 'kafka_cluster'")
             __props__.__dict__["kafka_cluster"] = kafka_cluster
@@ -471,6 +516,7 @@ class KafkaTopic(pulumi.CustomResource):
             opts: Optional[pulumi.ResourceOptions] = None,
             config: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
             credentials: Optional[pulumi.Input[pulumi.InputType['KafkaTopicCredentialsArgs']]] = None,
+            http_endpoint: Optional[pulumi.Input[str]] = None,
             kafka_cluster: Optional[pulumi.Input[pulumi.InputType['KafkaTopicKafkaClusterArgs']]] = None,
             partitions_count: Optional[pulumi.Input[int]] = None,
             rest_endpoint: Optional[pulumi.Input[str]] = None,
@@ -484,6 +530,7 @@ class KafkaTopic(pulumi.CustomResource):
         :param pulumi.ResourceOptions opts: Options for the resource.
         :param pulumi.Input[Mapping[str, pulumi.Input[str]]] config: The custom topic settings to set:
         :param pulumi.Input[pulumi.InputType['KafkaTopicCredentialsArgs']] credentials: The Cluster API Credentials.
+        :param pulumi.Input[str] http_endpoint: The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
         :param pulumi.Input[int] partitions_count: The number of partitions to create in the topic. Defaults to `6`.
         :param pulumi.Input[str] rest_endpoint: The REST endpoint of the Kafka cluster, for example, `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
         :param pulumi.Input[str] topic_name: The name of the topic, for example, `orders-1`. The topic name can be up to 249 characters in length, and can include the following characters: a-z, A-Z, 0-9, . (dot), _ (underscore), and - (dash). As a best practice, we recommend against using any personally identifiable information (PII) when naming your topic.
@@ -494,6 +541,7 @@ class KafkaTopic(pulumi.CustomResource):
 
         __props__.__dict__["config"] = config
         __props__.__dict__["credentials"] = credentials
+        __props__.__dict__["http_endpoint"] = http_endpoint
         __props__.__dict__["kafka_cluster"] = kafka_cluster
         __props__.__dict__["partitions_count"] = partitions_count
         __props__.__dict__["rest_endpoint"] = rest_endpoint
@@ -515,6 +563,14 @@ class KafkaTopic(pulumi.CustomResource):
         The Cluster API Credentials.
         """
         return pulumi.get(self, "credentials")
+
+    @property
+    @pulumi.getter(name="httpEndpoint")
+    def http_endpoint(self) -> pulumi.Output[str]:
+        """
+        The HTTP endpoint of the Kafka cluster (e.g., `https://pkc-00000.us-central1.gcp.confluent.cloud:443`).
+        """
+        return pulumi.get(self, "http_endpoint")
 
     @property
     @pulumi.getter(name="kafkaCluster")


### PR DESCRIPTION
Fixes: #5

[![asciicast](https://asciinema.org/a/XXIVTJkrdRTW9YQLClI996flR.svg)](https://asciinema.org/a/XXIVTJkrdRTW9YQLClI996flR)

In order to upgrade, you will need to install the new version - releasing as v1.1.1

then run:

`pulumi refresh` and you will see an added property for `restEndpoint` when that is available, you can change your code from `httpEndpoint` to `restEndpoint` (or whatever params your language expect) in the kafka.Topic resource

That will allow a pulumi up :)